### PR TITLE
TV guide now displays the wofford channel guide page

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -30,4 +30,20 @@
   <component name="ProjectType">
     <option name="id" value="Android" />
   </component>
+  <component name="masterDetails">
+    <states>
+      <state key="ProjectJDKs.UI">
+        <settings>
+          <last-edited>1.8</last-edited>
+          <splitter-proportions>
+            <option name="proportions">
+              <list>
+                <option value="0.2" />
+              </list>
+            </option>
+          </splitter-proportions>
+        </settings>
+      </state>
+    </states>
+  </component>
 </project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
-    <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>
 </project>

--- a/app/src/main/java/edu/wofford/sykesda/wocoapptest/tv_guide.java
+++ b/app/src/main/java/edu/wofford/sykesda/wocoapptest/tv_guide.java
@@ -2,12 +2,19 @@ package edu.wofford.sykesda.wocoapptest;
 
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
 
 public class tv_guide extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        WebView tv_guide_page;
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_tv_guide);
+
+            tv_guide_page = findViewById(R.id.tvguide);
+            tv_guide_page.setWebViewClient(new WebViewClient());
+            tv_guide_page.loadUrl("https://www.wofford.edu/technology/CableChanges/");
     }
 }

--- a/app/src/main/res/layout/activity_tv_guide.xml
+++ b/app/src/main/res/layout/activity_tv_guide.xml
@@ -6,17 +6,14 @@
     android:layout_height="match_parent"
     tools:context="edu.wofford.sykesda.wocoapptest.tv_guide">
 
-    <TextView
-        android:id="@+id/textView3"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        android:text="TV Guide goes here"
+    <WebView
+        android:id="@+id/tvguide"
+        android:layout_width="368dp"
+        android:layout_height="495dp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:layout_editor_absoluteX="8dp"
+        tools:layout_editor_absoluteY="8dp" />
 </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
The tv_guide activity now displays the Wofford channel guide web page
within the app. The visuals aren't ideal, but are the best we have to
work with given the non-mobile friendly nature of the site, and have
been approved by the project owners.